### PR TITLE
Update docs for SDK 3.5.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,15 +12,15 @@ The Approov integration is available via [`maven`](https://mvnrepository.com/rep
 The `Maven` repository is already present in the gradle.build file so the only import you need to make is the actual service layer itself:
 
 ```
-implementation("io.approov:service.okhttp:3.5.0")
+implementation("io.approov:service.okhttp:3.5.1")
 ```
 
 Make sure you do a Gradle sync (by selecting `Sync Now` in the banner at the top of the modified `.gradle` file) after making these changes.
 
-This package is actually an open source wrapper layer that allows you to easily use Approov with `OkHttp`. This has a further dependency to the closed source [Approov SDK](https://central.sonatype.com/artifact/io.approov/approov-android-sdk/3.5.0). In some cases you may need to also add this implementation to your dependencies list to avoid build errors:
+This package is actually an open source wrapper layer that allows you to easily use Approov with `OkHttp`. This has a further dependency to the closed source [Approov SDK](https://central.sonatype.com/artifact/io.approov/approov-android-sdk/3.5.1). In some cases you may need to also add this implementation to your dependencies list to avoid build errors:
 
 ```
-implementation("io.approov:approov-android-sdk:3.5.0")
+implementation("io.approov:approov-android-sdk:3.5.1")
 ```
 
 

--- a/SHAPES-EXAMPLE.md
+++ b/SHAPES-EXAMPLE.md
@@ -46,7 +46,7 @@ The `approov-service-okhttp` dependency needs to be added as follows to the `app
 The Maven dependency reference is:
 
 ```
-implementation("io.approov:service.okhttp:3.5.0")
+implementation("io.approov:service.okhttp:3.5.1")
 ```
 
 Make sure you do a Gradle sync (by selecting `Sync Now` in the banner at the top of the modified `build.gradle` file) after making these changes.


### PR DESCRIPTION
Quickstart was tested locally - initialisation of 3.5.1 successful, token obtained. 